### PR TITLE
feat: redesign homepage with inline tool results

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,11 @@ is meant to grow into a library of amateur‑radio utilities exposed over HTTP.
 
 ## Web Interface
 
-The root endpoint (`/`) serves a minimal single‑page app that works on desktop
-and mobile browsers. It provides a form for callsign lookups and displays the
-JSON response from the service.
+The root endpoint (`/`) serves a simple single‑column interface that works on
+desktop and mobile browsers. Each tool accepts a callsign query and shows the
+JSON response inline with a loading indicator. The current tools cover
+HamDB callsign lookups and APRS location and weather data from aprs.fi. A band
+plan viewer is coming soon.
 
 ## API Usage
 

--- a/hamops/web/index.html
+++ b/hamops/web/index.html
@@ -27,159 +27,116 @@
       min-height: 100vh;
     }
     header {
-      padding: 1rem 2rem;
+      padding: 1rem 1.5rem;
       display: flex;
-      justify-content: space-between;
       align-items: center;
+      gap: 0.5rem;
     }
-    .brand { display: flex; align-items: center; gap: 0.5rem; }
-    .logo { width: 32px; height: 32px; }
-    header h1 { margin: 0; font-size: 1.5rem; }
-    nav a {
-      margin-left: 1rem;
-      text-decoration: none;
-      color: var(--fg);
-      font-weight: 500;
-      display: inline-flex;
-      align-items: center;
-      gap: 0.25rem;
-    }
-    nav img { width: 20px; height: 20px; }
-    main { flex: 1; max-width: 960px; margin: 0 auto; padding: 2rem; }
-    .hero { text-align: center; padding: 3rem 1rem; }
-    .hero-title { font-size: 2.5rem; margin: 0 0 1rem; }
-    .hero-subtitle { color: var(--muted); font-size: 1.2rem; margin: 0 0 2rem; }
-    .intro { max-width: 720px; margin: 0 auto; text-align: center; line-height: 1.5; }
-    section h2 { text-align: center; margin-top: 3rem; }
-    .tool-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      gap: 1.5rem;
-      margin-top: 2rem;
-    }
-    .tool {
-      background: var(--card);
-      border-radius: 8px;
-      padding: 1.5rem;
-      box-shadow: 0 2px 4px rgba(0,0,0,.05);
-    }
-    .tool h3 { margin-top: 0; }
-    .tool-controls { display: flex; gap: 0.5rem; margin-top: 1rem; }
-    input, button { font-size: 1rem; padding: 0.5rem; }
+    header img { width: 32px; height: 32px; }
+    header h1 { margin: 0; font-size: 1.25rem; }
+    main { flex: 1; width: 100%; max-width: 600px; margin: 0 auto; padding: 2rem 1rem; }
+    .feature { padding: 1.5rem 0; border-bottom: 1px solid rgba(0,0,0,0.1); }
+    .feature:last-child { border-bottom: none; }
+    .feature h3 { margin: 0 0 0.25rem; }
+    .feature p { margin: 0.25rem 0 0; color: var(--muted); }
+    .controls { display: flex; gap: 0.5rem; margin-top: 1rem; }
+    input { flex: 1; padding: 0.5rem; font-size: 1rem; }
     button {
+      padding: 0.5rem 1rem;
+      font-size: 1rem;
       background: var(--accent);
-      color: white;
+      color: #fff;
       border: none;
       border-radius: 4px;
       cursor: pointer;
     }
-    dialog {
-      border: none;
-      border-radius: 8px;
-      padding: 1rem;
-      width: 90%;
-      max-width: 600px;
-    }
-    dialog::backdrop {
-      background: rgba(0,0,0,0.3);
-    }
+    .result { margin-top: 1rem; }
     pre { background: #f0f0f0; padding: 1rem; overflow-x: auto; }
+    .spinner {
+      width: 24px; height: 24px;
+      border: 3px solid var(--accent);
+      border-top-color: transparent;
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+      margin: 0 auto;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
     footer { font-size: 0.875rem; color: var(--muted); text-align: center; padding: 2rem 0; }
   </style>
 </head>
 <body>
   <header>
-    <div class="brand">
-      <img src="/web/logo.svg" alt="HamOps logo" class="logo" />
-      <h1>HamOps</h1>
-    </div>
-    <nav>
-      <a href="https://github.com/DomCritchlow/hamops" target="_blank" rel="noopener">
-        <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub" />
-        GitHub
-      </a>
-    </nav>
+    <img src="/web/logo.svg" alt="HamOps logo" />
+    <h1>HamOps</h1>
   </header>
-  <main>
-    <section class="hero">
-      <h2 class="hero-title">Ham Operations Center</h2>
-      <p class="hero-subtitle">Everyday tools for amateur radio, accessible via web, API, and MCP.</p>
-    </section>
-    <section class="intro">
-      <p>HamOps brings together utilities that radio amateurs reach for every day. Invoke tools directly from the browser or call the underlying API endpoints.</p>
-    </section>
-
-    <section id="tools">
-      <h2>Tools Available Now</h2>
-      <div class="tool-grid">
-        <div class="tool">
-          <h3>Callsign Lookup</h3>
-          <p>Search FCC registration data.</p>
-          <div class="tool-controls">
-            <input id="cs-lookup" placeholder="KK4ZMR" />
-            <button onclick="invoke('/api/callsign/' + document.getElementById('cs-lookup').value)">Query</button>
-          </div>
-        </div>
-        <div class="tool">
-          <h3>APRS Locations</h3>
-          <p>Get latest location reports.</p>
-          <div class="tool-controls">
-            <input id="aprs-loc" placeholder="KD4PMP" />
-            <button onclick="invoke('/api/aprs/locations/' + document.getElementById('aprs-loc').value)">Query</button>
-          </div>
-        </div>
-        <div class="tool">
-          <h3>APRS Weather</h3>
-          <p>Retrieve weather station data.</p>
-          <div class="tool-controls">
-            <input id="aprs-wx" placeholder="KD4PMP" />
-            <button onclick="invoke('/api/aprs/weather/' + document.getElementById('aprs-wx').value)">Query</button>
-          </div>
-        </div>
-        <div class="tool">
-          <h3>APRS Messages</h3>
-          <p>Read recent APRS text messages.</p>
-          <div class="tool-controls">
-            <input id="aprs-msg" placeholder="CALLSIGN" />
-            <button onclick="invoke('/api/aprs/messages/' + document.getElementById('aprs-msg').value)">Query</button>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <section id="coming-soon">
-      <h2>Coming Soon</h2>
-      <div class="tool-grid">
-        <div class="tool">
-          <h3>Frequency Planner</h3>
-          <p>Plan your bands and allocations.</p>
-        </div>
-        <div class="tool">
-          <h3>Logbook</h3>
-          <p>Track contacts and sync with popular services.</p>
-        </div>
-        <div class="tool">
-          <h3>LLM Co&#8209;Pilot</h3>
-          <p>Control radio operations with natural language.</p>
-        </div>
-      </div>
-    </section>
-  </main>
+  <main id="app"></main>
   <footer>&copy; 2025 HamOps</footer>
-
-  <dialog id="code-modal">
-    <pre id="code-output"></pre>
-    <div style="text-align:right;margin-top:1rem;">
-      <button onclick="document.getElementById('code-modal').close()">Close</button>
-    </div>
-  </dialog>
   <script>
-    async function invoke(url) {
-      const r = await fetch(url);
-      const data = await r.json();
-      document.getElementById('code-output').textContent = JSON.stringify(data, null, 2);
-      document.getElementById('code-modal').showModal();
+    // Feature definitions for easy extension
+    const features = [
+      {
+        id: 'callsign',
+        title: 'Callsign Lookup',
+        description: 'Look up FCC registration data via <a href="https://hamdb.org" target="_blank">hamdb.org</a>.',
+        placeholder: 'KK4ZMR',
+        endpoint: v => `/api/callsign/${v}`,
+      },
+      {
+        id: 'aprs-location',
+        title: 'APRS Locations',
+        description: 'Retrieve latest location reports from <a href="https://aprs.fi" target="_blank">aprs.fi</a>.',
+        placeholder: 'KD4PMP',
+        endpoint: v => `/api/aprs/locations/${v}`,
+      },
+      {
+        id: 'aprs-weather',
+        title: 'APRS Weather',
+        description: 'Fetch current weather data from <a href="https://aprs.fi" target="_blank">aprs.fi</a>.',
+        placeholder: 'KD4PMP',
+        endpoint: v => `/api/aprs/weather/${v}`,
+      },
+      {
+        id: 'band-plan',
+        title: 'Band Plan',
+        description: 'Explore amateur radio band allocations (coming soon).',
+      },
+    ];
+
+    const app = document.getElementById('app');
+    for (const f of features) {
+      const row = document.createElement('div');
+      row.className = 'feature';
+      row.innerHTML = `
+        <h3>${f.title}</h3>
+        <p>${f.description}</p>
+        ${f.endpoint ? `
+          <div class="controls">
+            <input id="${f.id}-input" placeholder="${f.placeholder || ''}" />
+            <button data-id="${f.id}">Query</button>
+          </div>
+        ` : ''}
+        <div class="result" id="${f.id}-result"></div>
+      `;
+      app.appendChild(row);
     }
+
+    app.addEventListener('click', async (e) => {
+      if (e.target.tagName === 'BUTTON' && e.target.dataset.id) {
+        const id = e.target.dataset.id;
+        const feature = features.find((f) => f.id === id);
+        const input = document.getElementById(`${id}-input`);
+        const result = document.getElementById(`${id}-result`);
+        result.innerHTML = '<div class="spinner"></div>';
+        try {
+          const resp = await fetch(feature.endpoint(input.value));
+          const data = await resp.json();
+          result.innerHTML = '<pre>' + JSON.stringify(data, null, 2) + '</pre>';
+        } catch (err) {
+          result.textContent = 'Error fetching data';
+        }
+      }
+    });
   </script>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- Replace grid-based homepage with a minimal single-column layout
- Show query results inline with a themed loading spinner and feature descriptions
- Update README to describe new extensible web interface

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a332ffceac8333aad6c47b9945990f